### PR TITLE
feat: Add remove_field(field) mutation to NoSQL QueryBuilder

### DIFF
--- a/coffy/nosql/engine.py
+++ b/coffy/nosql/engine.py
@@ -57,6 +57,29 @@ class QueryBuilder:
             doc = doc[k]
         return doc
 
+    @staticmethod
+    def _remove_nested(doc, dotted_key):
+        """
+        Remove a nested field from a document using a dotted key.
+        dotted_key -- A string representing the path to the field, e.g., "a.b.c".
+        Returns True if the field was removed, False if it didn't exist.
+        """
+        keys = dotted_key.split(".")
+        current = doc
+
+        # Navigate to the parent of the target field
+        for k in keys[:-1]:
+            if not isinstance(current, dict) or k not in current:
+                return False
+            current = current[k]
+
+        # Remove the target field
+        target_key = keys[-1]
+        if isinstance(current, dict) and target_key in current:
+            del current[target_key]
+            return True
+        return False
+
     def where(self, field):
         """
         Set the current field for filtering.
@@ -333,6 +356,33 @@ class QueryBuilder:
 
         self.collection._save()
         return {"replaced": replaced}
+
+    def remove_field(self, field):
+        """
+        Remove the specified field from documents that match the current filters.
+        field -- The field to remove, can be a dotted path like "a.b.c".
+        Returns a dictionary with the count of documents actually modified.
+        """
+        if not self.collection:
+            raise RuntimeError(
+                "Cannot propagate remove_field without CollectionManager."
+            )
+
+        removed_count = 0
+        for doc in self.collection.documents:
+            if all(f(doc) for f in self.filters):
+                # Remove old index before modifying the document
+                self.index_manager.remove(doc)
+
+                # Remove the field and check if it was actually removed
+                if QueryBuilder._remove_nested(doc, field):
+                    removed_count += 1
+
+                # Re-index the modified document
+                self.index_manager.index(doc)
+
+        self.collection._save()
+        return {"removed": removed_count}
 
     def count(self):
         """
@@ -724,6 +774,18 @@ class CollectionManager:
         Returns a list of all documents.
         """
         return self.documents
+
+    def remove_field(self, field):
+        """
+        Remove the specified field from all documents in the collection.
+        field -- The field to remove, can be a dotted path like "a.b.c".
+        Returns a dictionary with the count of documents actually modified.
+        """
+        return QueryBuilder(
+            self.documents,
+            all_collections=_collection_registry,
+            collection_name=self.name,
+        ).remove_field(field)
 
     def view(self):
         """

--- a/tests/test_nosql.py
+++ b/tests/test_nosql.py
@@ -283,6 +283,153 @@ class TestCollectionManager(unittest.TestCase):
             self.assertIn("total_spent", r)
         self.assertNotIn("age", r)  # `find()` excludes age
 
+    def test_remove_field_top_level(self):
+        """Test removing top-level fields from documents."""
+        self.col.clear()
+        self.col.add_many([
+            {"id": 1, "name": "Alice", "age": 30, "city": "Indy"},
+            {"id": 2, "name": "Bob", "age": 25, "city": "NYC"},
+            {"id": 3, "name": "Carl", "age": 35}
+        ])
+
+        # Remove 'city' field from all documents
+        result = self.col.remove_field("city")
+        self.assertEqual(result["removed"], 2)  # Only 2 docs had 'city' field
+
+        # Verify the field was removed
+        docs = self.col.all_docs()
+        self.assertEqual(len(docs), 3)
+        for doc in docs:
+            self.assertNotIn("city", doc)
+            self.assertIn("name", doc)  # Other fields should remain
+            self.assertIn("age", doc)
+
+    def test_remove_field_nested(self):
+        """Test removing nested fields using dot-notation."""
+        self.col.clear()
+        self.col.add_many([
+            {"id": 1, "name": "Alice", "profile": {"age": 30, "city": "Indy"}},
+            {"id": 2, "name": "Bob", "profile": {"age": 25}},
+            {"id": 3, "name": "Carl"}
+        ])
+
+        # Remove only the nested 'city' field from profiles
+        result = self.col.remove_field("profile.city")
+        self.assertEqual(result["removed"], 1)  # Only 1 doc had 'profile.city'
+
+        # Verify the nested field was removed
+        docs = self.col.all_docs()
+        self.assertEqual(len(docs), 3)
+        
+        # Check Alice's document
+        alice = next(doc for doc in docs if doc["name"] == "Alice")
+        self.assertIn("profile", alice)
+        self.assertIn("age", alice["profile"])
+        self.assertNotIn("city", alice["profile"])
+        
+        # Check Bob's document
+        bob = next(doc for doc in docs if doc["name"] == "Bob")
+        self.assertIn("profile", bob)
+        self.assertIn("age", bob["profile"])
+        
+        # Check Carl's document (no profile)
+        carl = next(doc for doc in docs if doc["name"] == "Carl")
+        self.assertNotIn("profile", carl)
+
+    def test_remove_field_deeply_nested(self):
+        """Test removing deeply nested fields."""
+        self.col.clear()
+        self.col.add_many([
+            {"id": 1, "data": {"user": {"preferences": {"theme": "dark", "lang": "en"}}}},
+            {"id": 2, "data": {"user": {"preferences": {"theme": "light"}}}},
+            {"id": 3, "data": {"user": {"name": "John"}}}
+        ])
+
+        # Remove deeply nested field
+        result = self.col.remove_field("data.user.preferences.theme")
+        self.assertEqual(result["removed"], 2)  # 2 docs had this field
+
+        # Verify the field was removed
+        docs = self.col.all_docs()
+        doc1 = next(doc for doc in docs if doc["id"] == 1)
+        doc2 = next(doc for doc in docs if doc["id"] == 2)
+        doc3 = next(doc for doc in docs if doc["id"] == 3)
+
+        self.assertNotIn("theme", doc1["data"]["user"]["preferences"])
+        self.assertIn("lang", doc1["data"]["user"]["preferences"])
+        self.assertNotIn("theme", doc2["data"]["user"]["preferences"])
+        self.assertIn("name", doc3["data"]["user"])
+
+    def test_remove_field_missing_field(self):
+        """Test removing fields that don't exist (should not error)."""
+        self.col.clear()
+        self.col.add_many([
+            {"id": 1, "name": "Alice"},
+            {"id": 2, "name": "Bob"}
+        ])
+
+        # Try to remove non-existent fields
+        result1 = self.col.remove_field("nonexistent")
+        result2 = self.col.remove_field("deeply.nested.nonexistent")
+        
+        self.assertEqual(result1["removed"], 0)
+        self.assertEqual(result2["removed"], 0)
+
+        # Documents should remain unchanged
+        docs = self.col.all_docs()
+        self.assertEqual(len(docs), 2)
+        for doc in docs:
+            self.assertIn("name", doc)
+
+    def test_remove_field_with_filter(self):
+        """Test removing fields only from documents matching a filter."""
+        self.col.clear()
+        self.col.add_many([
+            {"id": 1, "name": "Alice", "age": 30, "city": "Indy"},
+            {"id": 2, "name": "Bob", "age": 25, "city": "NYC"},
+            {"id": 3, "name": "Carl", "age": 35, "city": "LA"}
+        ])
+
+        # Remove 'city' only from documents where age > 28
+        result = self.col.where("age").gt(28).remove_field("city")
+        self.assertEqual(result["removed"], 2)  # Alice and Carl
+
+        # Verify the results
+        docs = self.col.all_docs()
+        alice = next(doc for doc in docs if doc["name"] == "Alice")
+        bob = next(doc for doc in docs if doc["name"] == "Bob")
+        carl = next(doc for doc in docs if doc["name"] == "Carl")
+
+        self.assertNotIn("city", alice)  # Removed (age 30)
+        self.assertIn("city", bob)       # Not removed (age 25)
+        self.assertNotIn("city", carl)   # Removed (age 35)
+
+    def test_remove_field_count_accuracy(self):
+        """Test that the returned count accurately reflects documents modified."""
+        self.col.clear()
+        self.col.add_many([
+            {"id": 1, "name": "Alice", "profile": {"age": 30, "city": "Indy"}},
+            {"id": 2, "name": "Bob", "profile": {"age": 25}},
+            {"id": 3, "name": "Carl"},
+            {"id": 4, "name": "Dave", "profile": {"age": 40, "city": "NYC"}}
+        ])
+
+        # Remove 'profile.city' - should affect 2 documents
+        result = self.col.remove_field("profile.city")
+        self.assertEqual(result["removed"], 2)
+
+        # Remove 'profile.age' - should affect 3 documents
+        result = self.col.remove_field("profile.age")
+        self.assertEqual(result["removed"], 3)
+
+        # Remove 'name' - should affect all 4 documents
+        result = self.col.remove_field("name")
+        self.assertEqual(result["removed"], 4)
+
+        # Try to remove non-existent field - should affect 0 documents
+        result = self.col.remove_field("nonexistent")
+        self.assertEqual(result["removed"], 0)
+
 
 unittest.TextTestRunner().run(
     unittest.TestLoader().loadTestsFromTestCase(TestCollectionManager)


### PR DESCRIPTION
#47 closes.
**Issue Analysis**
Goal: Add remove_field(field) method to NoSQL QueryBuilder
Requirements: Support dot-notation, return count, handle missing fields gracefully
Files: coffy/nosql/engine.py, tests/test_nosql.py
**Implementation Steps**
Add helper function _remove_nested() for dot-notation field removal
Add remove_field() method to QueryBuilder class
Add convenience method to CollectionManager
Write comprehensive tests (6 test methods)
Code quality: Black formatting + Ruff linting

**Status: COMPLETE**
All code implemented and tested
<img width="1259" height="301" alt="image" src="https://github.com/user-attachments/assets/4f5679da-4a63-447a-98d0-3f6c01534133" />

84 tests passing (6 new tests added)
<img width="1027" height="603" alt="image" src="https://github.com/user-attachments/assets/63f66335-5980-4ede-9a40-e5b94ca58739" />


Code quality checks passed
<img width="835" height="63" alt="image" src="https://github.com/user-attachments/assets/ececce11-d6bf-4677-b6f2-c1e8eec5452f" />
