### PR TITLE
Adding SQL columns property

### DIFF
--- a/coffy/sql/sqldict.py
+++ b/coffy/sql/sqldict.py
@@ -20,8 +20,10 @@ class SQLDict(Sequence):
         """
         Initialize with a list of dictionaries or a single dictionary.
         data -- list or dict - The SQL query results.
+        columns -- List of column names derived from the SQL results, returns empty list if no rows are returned.
         """
         self._data = data if isinstance(data, list) else [data]
+        self.columns = list(self._data[0].keys()) if self._data else []
 
     def __getitem__(self, index):
         """

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -68,6 +68,18 @@ class TestSQLModule(unittest.TestCase):
         os.remove(temp_json)
         os.remove(temp_csv)
 
+    def test_column_property(self):
+        result = query("SELECT * FROM users WHERE id = 1")
+        self.assertEqual(result.columns, ["id", "name", "age"])
+
+    def test_column_property_empty(self):
+        result = query("SELECT * FROM users WHERE 1=0")
+        self.assertEqual(result.columns, [])
+
+    def test_column_property_out_of_order(self):
+        result = query("SELECT * FROM users ORDER BY age DESC")
+        self.assertNotEqual(result.columns, ["id", "age", "name"])
+
 
 unittest.TextTestRunner().run(
     unittest.TestLoader().loadTestsFromTestCase(TestSQLModule)


### PR DESCRIPTION
Adding the `.columns` property to `SQLDict` class - returning a list of columns in order, or an empty list when no results are returned. 

Updated tests to reflect.

Resolving #42 