### PR TITLE
GraphDB - Implement remove relationships by type

### DIFF
--- a/coffy/graph/graphdb_nx.py
+++ b/coffy/graph/graphdb_nx.py
@@ -157,6 +157,17 @@ class GraphDB:
         self.g.remove_edge(source, target)
         self._persist()
 
+    def remove_relationships_by_type(self, type):
+        """
+        Remove all relationships of a specific type.
+        type -- Type of the relationship to remove.
+        """
+        edges_to_remove = [
+            (u, v) for u, v, a in self.g.edges(data=True) if a.get("_type") == type
+        ]
+        self.g.remove_edges_from(edges_to_remove)
+        self._persist()
+
     # Basic queries
     def neighbors(self, node_id):
         """

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -76,6 +76,14 @@ class TestGraphDB(unittest.TestCase):
         self.db.remove_relationship("A", "B")
         self.assertFalse(self.db.has_relationship("A", "B"))
 
+    def test_remove_relationships_by_type(self):
+        self.db.add_relationship("A", "C", rel_type="KNOWS OF", since=2010)
+        self.assertEqual(self.db.count_relationships_by_type("KNOWS"), 2)
+        self.assertEqual(self.db.count_relationships_by_type("KNOWS OF"), 1)
+        self.db.remove_relationships_by_type("KNOWS")
+        self.assertEqual(self.db.count_relationships_by_type("KNOWS"), 0)
+        self.assertEqual(self.db.count_relationships_by_type("KNOWS OF"), 1)
+
     def test_find_nodes_basic(self):
         results = self.db.find_nodes(name="Alice")
         self.assertEqual(len(results), 1)


### PR DESCRIPTION
Added the method to remove relationships by type in GraphDB, resolving #49 